### PR TITLE
`feat` Integrate the `maniac-tech/react-native-expo-read-sms` at `9.1.1`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ web-build/
 
 # macOS
 .DS_Store
+
+# android
+/android

--- a/App.js
+++ b/App.js
@@ -1,130 +1,185 @@
-import { StatusBar } from "expo-status-bar";
-import { StyleSheet, Text, View } from "react-native";
+import React, { useState } from "react";
 import {
-  Button,
-  DataTable,
-  Title,
-  Provider as PaperProvider,
-  Divider,
-} from "react-native-paper";
-
-import useApp from "./useApp";
-
-const PermissionStatus = ({
-  READ_SMS_PERMISSION_STATUS,
-  RECEIVE_SMS_PERMISSION_STATUS,
+  StyleSheet,
+  Text,
+  View,
+  TouchableOpacity,
+  ScrollView,
+  SafeAreaView,
+} from "react-native";
+import { StatusBar } from "expo-status-bar";
+import {
+  startReadSMS,
+  stopReadSMS,
+  checkIfHasSMSPermission,
   requestReadSMSPermission,
-}) => {
-  console.log(
-    "READ_SMS_PERMISSION_STATUS, RECEIVE_SMS_PERMISSION_STATUS:",
-    READ_SMS_PERMISSION_STATUS,
-    RECEIVE_SMS_PERMISSION_STATUS
-  );
-  return (
-    <DataTable>
-      <DataTable.Header>
-        <DataTable.Title>Permission Status</DataTable.Title>
-      </DataTable.Header>
-
-      <DataTable.Row>
-        <DataTable.Cell>READ_SMS:</DataTable.Cell>
-        <DataTable.Cell>
-          {READ_SMS_PERMISSION_STATUS + "" || "null"}
-        </DataTable.Cell>
-      </DataTable.Row>
-      <DataTable.Row>
-        <DataTable.Cell>RECEIVE_SMS:</DataTable.Cell>
-        <DataTable.Cell>
-          {RECEIVE_SMS_PERMISSION_STATUS + "" || "null"}
-        </DataTable.Cell>
-      </DataTable.Row>
-
-      {(!READ_SMS_PERMISSION_STATUS || !RECEIVE_SMS_PERMISSION_STATUS) && (
-        <Button onPress={requestReadSMSPermission} mode="contained">
-          Request Permission
-        </Button>
-      )}
-    </DataTable>
-  );
-};
+} from "@maniac-tech/react-native-expo-read-sms";
 
 export default function App() {
-  const {
-    appState,
-    buttonClickHandler,
-    checkPermissions,
-    errorCallbackStatus,
-    hasReceiveSMSPermission,
-    hasReadSMSPermission,
-    requestReadSMSPermission,
-    smsPermissionState,
-    successCallbackStatus,
-    smsMessageBody,
-    smsMessageNumber,
-    smsError,
-  } = useApp();
+  const [logs, setLogs] = useState([]);
+  const [isListening, setIsListening] = useState(false);
+  const [permissionStatus, setPermissionStatus] = useState(null);
+
+  const addLog = (message, type = "info") => {
+    const timestamp = new Date().toLocaleTimeString();
+    setLogs((prev) => [{ message, type, timestamp }, ...prev]);
+  };
+
+  // ─── Test: checkIfHasSMSPermission ──────────────────────────────────────────
+  const handleCheckPermission = async () => {
+    addLog("Checking SMS permissions...");
+    try {
+      const result = await checkIfHasSMSPermission();
+      setPermissionStatus(result);
+      addLog(
+        `READ_SMS: ${result.hasReadSmsPermission}, RECEIVE_SMS: ${result.hasReceiveSmsPermission}`,
+        result.hasReadSmsPermission && result.hasReceiveSmsPermission
+          ? "success"
+          : "warning"
+      );
+    } catch (e) {
+      addLog(`Error checking permission: ${e.message}`, "error");
+    }
+  };
+
+  // ─── Test: requestReadSMSPermission ─────────────────────────────────────────
+  const handleRequestPermission = async () => {
+    addLog("Requesting SMS permissions...");
+    try {
+      const granted = await requestReadSMSPermission();
+      addLog(
+        granted ? "Permissions granted ✓" : "Permissions denied ✗",
+        granted ? "success" : "error"
+      );
+      // Refresh permission status after request
+      await handleCheckPermission();
+    } catch (e) {
+      addLog(`Error requesting permission: ${e.message}`, "error");
+    }
+  };
+
+  // ─── Test: startReadSMS ──────────────────────────────────────────────────────
+  const handleStartListening = async () => {
+    addLog("Starting SMS listener...");
+    try {
+      await startReadSMS((status, sms, error) => {
+        if (status === "success") {
+          addLog(`SMS received: ${sms}`, "success");
+          setIsListening(true);
+        } else {
+          addLog(`SMS listener error: ${error}`, "error");
+          setIsListening(false);
+        }
+      });
+      setIsListening(true);
+      addLog("SMS listener started — send an SMS to test ✓", "success");
+    } catch (e) {
+      addLog(`Failed to start listener: ${e.message}`, "error");
+    }
+  };
+
+  // ─── Test: stopReadSMS ───────────────────────────────────────────────────────
+  const handleStopListening = () => {
+    addLog("Stopping SMS listener...");
+    try {
+      stopReadSMS();
+      setIsListening(false);
+      addLog("SMS listener stopped ✓", "success");
+    } catch (e) {
+      addLog(`Failed to stop listener: ${e.message}`, "error");
+    }
+  };
+
+  const clearLogs = () => setLogs([]);
 
   return (
-    <PaperProvider>
-      <View style={styles.container}>
-        <StatusBar style="auto" />
-        <Title>ExpoReadSMS - Test Application (Expo)</Title>
+    <SafeAreaView style={styles.container}>
+      <StatusBar style="auto" />
 
-        <DataTable>
-          <DataTable.Row>
-            <DataTable.Cell>App State:</DataTable.Cell>
-            <DataTable.Cell>{appState}</DataTable.Cell>
-          </DataTable.Row>
-        </DataTable>
-        <Divider />
-        <PermissionStatus
-          READ_SMS_PERMISSION_STATUS={hasReadSMSPermission}
-          RECEIVE_SMS_PERMISSION_STATUS={hasReceiveSMSPermission}
-          requestReadSMSPermission={requestReadSMSPermission}
-        />
-        <DataTable>
-          <DataTable.Row>
-            <DataTable.Cell>
-              <Text>smsPermissionState:</Text>
-            </DataTable.Cell>
-            <DataTable.Cell>{smsPermissionState + "" || "null"}</DataTable.Cell>
-          </DataTable.Row>
-          <DataTable.Row>
-            <DataTable.Cell>
-              <Text>smsMessageNumber:</Text>
-            </DataTable.Cell>
-            <DataTable.Cell>{smsMessageNumber + "" || "null"}</DataTable.Cell>
-          </DataTable.Row>
-          <DataTable.Row>
-            <DataTable.Cell>
-              <Text>smsMessageBody:</Text>
-            </DataTable.Cell>
-            <DataTable.Cell>{smsMessageBody + "" || "null"}</DataTable.Cell>
-          </DataTable.Row>
-          <DataTable.Row>
-            <DataTable.Cell>
-              <Text>smsError:</Text>
-            </DataTable.Cell>
-            <DataTable.Cell>{smsError + "" || "null"}</DataTable.Cell>
-          </DataTable.Row>
-
-          <Button onPress={checkPermissions} title="start" mode="contained">
-            Recheck permission state
-          </Button>
-          <Button onPress={buttonClickHandler} title="start" mode="contained">
-            Start
-          </Button>
-        </DataTable>
+      <View style={styles.header}>
+        <Text style={styles.title}>ExpoReadSMS TestApp</Text>
+        <Text style={styles.subtitle}>SDK 51 · RN 0.74 · Library v9.1.0</Text>
+        <View style={[styles.badge, isListening ? styles.badgeActive : styles.badgeInactive]}>
+          <Text style={styles.badgeText}>
+            {isListening ? "● Listening" : "○ Not Listening"}
+          </Text>
+        </View>
       </View>
-    </PaperProvider>
+
+      <View style={styles.buttonGrid}>
+        <TouchableOpacity style={[styles.button, styles.buttonSecondary]} onPress={handleCheckPermission}>
+          <Text style={styles.buttonText}>Check Permission</Text>
+        </TouchableOpacity>
+
+        <TouchableOpacity style={[styles.button, styles.buttonSecondary]} onPress={handleRequestPermission}>
+          <Text style={styles.buttonText}>Request Permission</Text>
+        </TouchableOpacity>
+
+        <TouchableOpacity
+          style={[styles.button, styles.buttonPrimary, isListening && styles.buttonDisabled]}
+          onPress={handleStartListening}
+          disabled={isListening}
+        >
+          <Text style={styles.buttonText}>Start Listening</Text>
+        </TouchableOpacity>
+
+        <TouchableOpacity
+          style={[styles.button, styles.buttonDanger, !isListening && styles.buttonDisabled]}
+          onPress={handleStopListening}
+          disabled={!isListening}
+        >
+          <Text style={styles.buttonText}>Stop Listening</Text>
+        </TouchableOpacity>
+      </View>
+
+      <View style={styles.logsHeader}>
+        <Text style={styles.logsTitle}>Logs</Text>
+        <TouchableOpacity onPress={clearLogs}>
+          <Text style={styles.clearText}>Clear</Text>
+        </TouchableOpacity>
+      </View>
+
+      <ScrollView style={styles.logsContainer}>
+        {logs.length === 0 && (
+          <Text style={styles.emptyLogs}>Tap a button above to begin testing.</Text>
+        )}
+        {logs.map((log, index) => (
+          <View key={index} style={[styles.logEntry, styles[`log_${log.type}`]]}>
+            <Text style={styles.logTime}>{log.timestamp}</Text>
+            <Text style={styles.logMessage}>{log.message}</Text>
+          </View>
+        ))}
+      </ScrollView>
+    </SafeAreaView>
   );
 }
 
 const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    backgroundColor: "#fff",
-    alignItems: "center",
-    justifyContent: "center",
-  },
+  container: { flex: 1, backgroundColor: "#f5f5f5" },
+  header: { padding: 20, backgroundColor: "#fff", alignItems: "center", borderBottomWidth: 1, borderBottomColor: "#e0e0e0" },
+  title: { fontSize: 20, fontWeight: "bold", color: "#1a1a1a" },
+  subtitle: { fontSize: 13, color: "#666", marginTop: 4 },
+  badge: { marginTop: 10, paddingHorizontal: 14, paddingVertical: 5, borderRadius: 20 },
+  badgeActive: { backgroundColor: "#d4edda" },
+  badgeInactive: { backgroundColor: "#f8d7da" },
+  badgeText: { fontSize: 13, fontWeight: "600" },
+  buttonGrid: { flexDirection: "row", flexWrap: "wrap", padding: 12, gap: 8 },
+  button: { flex: 1, minWidth: "45%", padding: 14, borderRadius: 10, alignItems: "center" },
+  buttonPrimary: { backgroundColor: "#007AFF" },
+  buttonSecondary: { backgroundColor: "#5856D6" },
+  buttonDanger: { backgroundColor: "#FF3B30" },
+  buttonDisabled: { opacity: 0.4 },
+  buttonText: { color: "#fff", fontWeight: "600", fontSize: 14 },
+  logsHeader: { flexDirection: "row", justifyContent: "space-between", alignItems: "center", paddingHorizontal: 16, paddingVertical: 8, backgroundColor: "#fff", borderBottomWidth: 1, borderBottomColor: "#e0e0e0" },
+  logsTitle: { fontSize: 15, fontWeight: "600" },
+  clearText: { fontSize: 14, color: "#007AFF" },
+  logsContainer: { flex: 1, padding: 12 },
+  emptyLogs: { color: "#999", textAlign: "center", marginTop: 40, fontSize: 14 },
+  logEntry: { padding: 10, marginBottom: 8, borderRadius: 8, borderLeftWidth: 4 },
+  log_info: { backgroundColor: "#e8f4f8", borderLeftColor: "#007AFF" },
+  log_success: { backgroundColor: "#d4edda", borderLeftColor: "#28a745" },
+  log_warning: { backgroundColor: "#fff3cd", borderLeftColor: "#ffc107" },
+  log_error: { backgroundColor: "#f8d7da", borderLeftColor: "#dc3545" },
+  logTime: { fontSize: 11, color: "#888", marginBottom: 2 },
+  logMessage: { fontSize: 13, color: "#1a1a1a" },
 });

--- a/app.json
+++ b/app.json
@@ -1,8 +1,9 @@
 {
   "expo": {
-    "name": "ExpoReadSMS-Test",
-    "slug": "ExpoReadSMS-Test",
+    "name": "ExpoReadSMS-TestApp",
+    "slug": "ExpoReadSMS-TestApp",
     "version": "1.0.0",
+    "sdkVersion": "51.0.0",
     "orientation": "portrait",
     "icon": "./assets/icon.png",
     "userInterfaceStyle": "light",
@@ -11,49 +12,28 @@
       "resizeMode": "contain",
       "backgroundColor": "#ffffff"
     },
-    "updates": {
-      "enabled": true,
-      "fallbackToCacheTimeout": 0,
-      "url": "https://u.expo.dev/645044d2-03a2-47c7-be5f-d5ff0f228cb7"
-    },
-    "assetBundlePatterns": [
-      "**/*"
-    ],
-    "ios": {
-      "supportsTablet": true
-    },
     "android": {
       "adaptiveIcon": {
         "foregroundImage": "./assets/adaptive-icon.png",
-        "backgroundColor": "#FFFFFF"
+        "backgroundColor": "#ffffff"
       },
-      "package": "com.maniactech.exporeadsmstest",
-      "permissions": []
-    },
-    "web": {
-      "favicon": "./assets/favicon.png"
+      "package": "com.maniactech.exporeadsms",
+      "permissions": [
+        "android.permission.RECEIVE_SMS",
+        "android.permission.READ_SMS"
+      ]
     },
     "plugins": [
-      "expo-updates",
       [
         "expo-build-properties",
         {
           "android": {
-            "minSdkVersion": 34,
             "compileSdkVersion": 34,
             "targetSdkVersion": 34,
-            "buildToolsVersion": "34.0.0"
+            "minSdkVersion": 21
           }
         }
       ]
-    ],
-    "runtimeVersion": {
-      "policy": "sdkVersion"
-    },
-    "extra": {
-      "eas": {
-        "projectId": "645044d2-03a2-47c7-be5f-d5ff0f228cb7"
-      }
-    }
+    ]
   }
 }

--- a/app.json
+++ b/app.json
@@ -30,7 +30,7 @@
           "android": {
             "compileSdkVersion": 34,
             "targetSdkVersion": 34,
-            "minSdkVersion": 21
+            "minSdkVersion": 23
           }
         }
       ]

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "expo-read-sms-test-app",
       "version": "1.0.0",
       "dependencies": {
-        "@maniac-tech/react-native-expo-read-sms": "^9.1.1",
+        "@maniac-tech/react-native-expo-read-sms": "^9.1.2",
         "expo": "^51.0.0",
         "expo-build-properties": "~0.12.5",
         "expo-dev-client": "~4.0.19",
@@ -3480,9 +3480,9 @@
       }
     },
     "node_modules/@maniac-tech/react-native-expo-read-sms": {
-      "version": "9.1.1",
-      "resolved": "https://registry.npmjs.org/@maniac-tech/react-native-expo-read-sms/-/react-native-expo-read-sms-9.1.1.tgz",
-      "integrity": "sha512-KVor4mu05aUFLij9YhZN73lwvcUGjewR5droG0FwAIgtqVBxDiWlTrHR9vTvVH2G8plRG1SNHeAQPSW3aJaySw==",
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/@maniac-tech/react-native-expo-read-sms/-/react-native-expo-read-sms-9.1.2.tgz",
+      "integrity": "sha512-K8+CGV2oPnJLhy0TiOURk7hXC4L+KgbbkXWAJTEh9b58UsbHcGHKrxwOGmpTbAO8wUKgQRWB53+LRSwFBmRTZg==",
       "license": "MIT",
       "peerDependencies": {
         "react-native": ">=0.73"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,28 +1,22 @@
 {
-  "name": "exporeadsms-test",
+  "name": "expo-read-sms-test-app",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "exporeadsms-test",
+      "name": "expo-read-sms-test-app",
       "version": "1.0.0",
       "dependencies": {
-        "@maniac-tech/react-native-expo-read-sms": "7.0.0",
-        "expo": "^51.0.0",
-        "expo-build-properties": "~0.12.3",
-        "expo-dev-client": "~4.0.19",
-        "expo-splash-screen": "~0.27.5",
+        "@maniac-tech/react-native-expo-read-sms": "^9.1.1",
+        "expo": "~51.0.0",
+        "expo-build-properties": "~0.12.5",
         "expo-status-bar": "~1.12.1",
-        "expo-updates": "~0.25.18",
         "react": "18.2.0",
-        "react-dom": "18.2.0",
-        "react-native": "0.74.3",
-        "react-native-paper": "^4.12.2",
-        "react-native-web": "~0.19.6"
+        "react-native": "0.74.5"
       },
       "devDependencies": {
-        "@babel/core": "^7.12.9"
+        "@babel/core": "^7.24.0"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -1902,11 +1896,10 @@
       "license": "MIT"
     },
     "node_modules/@babel/runtime": {
-      "version": "7.24.7",
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.6.tgz",
+      "integrity": "sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==",
       "license": "MIT",
-      "dependencies": {
-        "regenerator-runtime": "^0.14.0"
-      },
       "engines": {
         "node": ">=6.9.0"
       }
@@ -1952,24 +1945,6 @@
       },
       "engines": {
         "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@callstack/react-theme-provider": {
-      "version": "3.0.9",
-      "license": "MIT",
-      "dependencies": {
-        "deepmerge": "^3.2.0",
-        "hoist-non-react-statics": "^3.3.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.3.0"
-      }
-    },
-    "node_modules/@callstack/react-theme-provider/node_modules/deepmerge": {
-      "version": "3.3.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/@expo/bunyan": {
@@ -2474,91 +2449,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/@expo/fingerprint": {
-      "version": "0.10.0",
-      "license": "MIT",
-      "dependencies": {
-        "@expo/spawn-async": "^1.7.2",
-        "chalk": "^4.1.2",
-        "debug": "^4.3.4",
-        "find-up": "^5.0.0",
-        "minimatch": "^3.0.4",
-        "p-limit": "^3.1.0",
-        "resolve-from": "^5.0.0",
-        "semver": "^7.6.0"
-      },
-      "bin": {
-        "fingerprint": "bin/cli.js"
-      }
-    },
-    "node_modules/@expo/fingerprint/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/@expo/fingerprint/node_modules/chalk": {
-      "version": "4.1.2",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/@expo/fingerprint/node_modules/color-convert": {
-      "version": "2.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/@expo/fingerprint/node_modules/color-name": {
-      "version": "1.1.4",
-      "license": "MIT"
-    },
-    "node_modules/@expo/fingerprint/node_modules/has-flag": {
-      "version": "4.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@expo/fingerprint/node_modules/semver": {
-      "version": "7.6.2",
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@expo/fingerprint/node_modules/supports-color": {
-      "version": "7.2.0",
-      "license": "MIT",
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/@expo/image-utils": {
       "version": "0.5.1",
       "license": "MIT",
@@ -2949,66 +2839,6 @@
         "@xmldom/xmldom": "~0.7.7",
         "base64-js": "^1.2.3",
         "xmlbuilder": "^14.0.0"
-      }
-    },
-    "node_modules/@expo/prebuild-config": {
-      "version": "7.0.6",
-      "license": "MIT",
-      "dependencies": {
-        "@expo/config": "~9.0.0-beta.0",
-        "@expo/config-plugins": "~8.0.0-beta.0",
-        "@expo/config-types": "^51.0.0-unreleased",
-        "@expo/image-utils": "^0.5.0",
-        "@expo/json-file": "^8.3.0",
-        "@react-native/normalize-colors": "0.74.84",
-        "debug": "^4.3.1",
-        "fs-extra": "^9.0.0",
-        "resolve-from": "^5.0.0",
-        "semver": "^7.6.0",
-        "xml2js": "0.6.0"
-      },
-      "peerDependencies": {
-        "expo-modules-autolinking": ">=0.8.1"
-      }
-    },
-    "node_modules/@expo/prebuild-config/node_modules/fs-extra": {
-      "version": "9.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "at-least-node": "^1.0.0",
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@expo/prebuild-config/node_modules/jsonfile": {
-      "version": "6.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "universalify": "^2.0.0"
-      },
-      "optionalDependencies": {
-        "graceful-fs": "^4.1.6"
-      }
-    },
-    "node_modules/@expo/prebuild-config/node_modules/semver": {
-      "version": "7.6.2",
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@expo/prebuild-config/node_modules/universalify": {
-      "version": "2.0.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 10.0.0"
       }
     },
     "node_modules/@expo/rudder-sdk-node": {
@@ -3444,7 +3274,9 @@
       }
     },
     "node_modules/@jridgewell/source-map": {
-      "version": "0.3.6",
+      "version": "0.3.11",
+      "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.11.tgz",
+      "integrity": "sha512-ZMp1V8ZFcPG5dIWnQLr3NSI1MiCU7UETdS/A0G8V/XWHvJv3ZsFqutJn1Y5RPmAPX6F3BiE397OqveU/9NCuIA==",
       "license": "MIT",
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.5",
@@ -3464,11 +3296,12 @@
       }
     },
     "node_modules/@maniac-tech/react-native-expo-read-sms": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@maniac-tech/react-native-expo-read-sms/-/react-native-expo-read-sms-7.0.0.tgz",
-      "integrity": "sha512-6CnwwS9r0/Rgz3ZlIUAiM+7npqVhr+vsAPwrKGmIROseGoq9jAJ6DhWr5raTbDYqiBE+K2P7zKb7o5GO7HgAXw==",
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/@maniac-tech/react-native-expo-read-sms/-/react-native-expo-read-sms-9.1.1.tgz",
+      "integrity": "sha512-KVor4mu05aUFLij9YhZN73lwvcUGjewR5droG0FwAIgtqVBxDiWlTrHR9vTvVH2G8plRG1SNHeAQPSW3aJaySw==",
+      "license": "MIT",
       "peerDependencies": {
-        "react-native": "0.74.3"
+        "react-native": ">=0.73"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -5181,7 +5014,9 @@
       }
     },
     "node_modules/@react-native/assets-registry": {
-      "version": "0.74.85",
+      "version": "0.74.87",
+      "resolved": "https://registry.npmjs.org/@react-native/assets-registry/-/assets-registry-0.74.87.tgz",
+      "integrity": "sha512-1XmRhqQchN+pXPKEKYdpJlwESxVomJOxtEnIkbo7GAlaN2sym84fHEGDXAjLilih5GVPpcpSmFzTy8jx3LtaFg==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -5272,13 +5107,15 @@
       }
     },
     "node_modules/@react-native/community-cli-plugin": {
-      "version": "0.74.85",
+      "version": "0.74.87",
+      "resolved": "https://registry.npmjs.org/@react-native/community-cli-plugin/-/community-cli-plugin-0.74.87.tgz",
+      "integrity": "sha512-EgJG9lSr8x3X67dHQKQvU6EkO+3ksVlJHYIVv6U/AmW9dN80BEFxgYbSJ7icXS4wri7m4kHdgeq2PQ7/3vvrTQ==",
       "license": "MIT",
       "dependencies": {
         "@react-native-community/cli-server-api": "13.6.9",
         "@react-native-community/cli-tools": "13.6.9",
-        "@react-native/dev-middleware": "0.74.85",
-        "@react-native/metro-babel-transformer": "0.74.85",
+        "@react-native/dev-middleware": "0.74.87",
+        "@react-native/metro-babel-transformer": "0.74.87",
         "chalk": "^4.0.0",
         "execa": "^5.1.1",
         "metro": "^0.80.3",
@@ -5292,8 +5129,43 @@
         "node": ">=18"
       }
     },
+    "node_modules/@react-native/community-cli-plugin/node_modules/@react-native/debugger-frontend": {
+      "version": "0.74.87",
+      "resolved": "https://registry.npmjs.org/@react-native/debugger-frontend/-/debugger-frontend-0.74.87.tgz",
+      "integrity": "sha512-MN95DJLYTv4EqJc+9JajA3AJZSBYJz2QEJ3uWlHrOky2vKrbbRVaW1ityTmaZa2OXIvNc6CZwSRSE7xCoHbXhQ==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@react-native/community-cli-plugin/node_modules/@react-native/dev-middleware": {
+      "version": "0.74.87",
+      "resolved": "https://registry.npmjs.org/@react-native/dev-middleware/-/dev-middleware-0.74.87.tgz",
+      "integrity": "sha512-7TmZ3hTHwooYgIHqc/z87BMe1ryrIqAUi+AF7vsD+EHCGxHFdMjSpf1BZ2SUPXuLnF2cTiTfV2RwhbPzx0tYIA==",
+      "license": "MIT",
+      "dependencies": {
+        "@isaacs/ttlcache": "^1.4.1",
+        "@react-native/debugger-frontend": "0.74.87",
+        "@rnx-kit/chromium-edge-launcher": "^1.0.0",
+        "chrome-launcher": "^0.15.2",
+        "connect": "^3.6.5",
+        "debug": "^2.2.0",
+        "node-fetch": "^2.2.0",
+        "nullthrows": "^1.1.1",
+        "open": "^7.0.3",
+        "selfsigned": "^2.4.1",
+        "serve-static": "^1.13.1",
+        "temp-dir": "^2.0.0",
+        "ws": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@react-native/community-cli-plugin/node_modules/ansi-styles": {
       "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -5307,6 +5179,8 @@
     },
     "node_modules/@react-native/community-cli-plugin/node_modules/chalk": {
       "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
@@ -5321,6 +5195,8 @@
     },
     "node_modules/@react-native/community-cli-plugin/node_modules/color-convert": {
       "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -5331,10 +5207,14 @@
     },
     "node_modules/@react-native/community-cli-plugin/node_modules/color-name": {
       "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "license": "MIT"
     },
     "node_modules/@react-native/community-cli-plugin/node_modules/cross-spawn": {
-      "version": "7.0.3",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
@@ -5345,8 +5225,19 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@react-native/community-cli-plugin/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
     "node_modules/@react-native/community-cli-plugin/node_modules/execa": {
       "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
+      "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
       "license": "MIT",
       "dependencies": {
         "cross-spawn": "^7.0.3",
@@ -5368,6 +5259,8 @@
     },
     "node_modules/@react-native/community-cli-plugin/node_modules/get-stream": {
       "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+      "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -5378,6 +5271,8 @@
     },
     "node_modules/@react-native/community-cli-plugin/node_modules/has-flag": {
       "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -5385,6 +5280,8 @@
     },
     "node_modules/@react-native/community-cli-plugin/node_modules/is-stream": {
       "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -5395,13 +5292,23 @@
     },
     "node_modules/@react-native/community-cli-plugin/node_modules/mimic-fn": {
       "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
       "license": "MIT",
       "engines": {
         "node": ">=6"
       }
     },
+    "node_modules/@react-native/community-cli-plugin/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
+    },
     "node_modules/@react-native/community-cli-plugin/node_modules/npm-run-path": {
       "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+      "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.0.0"
@@ -5412,6 +5319,8 @@
     },
     "node_modules/@react-native/community-cli-plugin/node_modules/onetime": {
       "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+      "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
       "license": "MIT",
       "dependencies": {
         "mimic-fn": "^2.1.0"
@@ -5423,8 +5332,26 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/@react-native/community-cli-plugin/node_modules/open": {
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/open/-/open-7.4.2.tgz",
+      "integrity": "sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q==",
+      "license": "MIT",
+      "dependencies": {
+        "is-docker": "^2.0.0",
+        "is-wsl": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/@react-native/community-cli-plugin/node_modules/path-key": {
       "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -5432,6 +5359,8 @@
     },
     "node_modules/@react-native/community-cli-plugin/node_modules/shebang-command": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
       "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
@@ -5442,6 +5371,8 @@
     },
     "node_modules/@react-native/community-cli-plugin/node_modules/shebang-regex": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -5449,6 +5380,8 @@
     },
     "node_modules/@react-native/community-cli-plugin/node_modules/supports-color": {
       "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
       "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
@@ -5459,6 +5392,8 @@
     },
     "node_modules/@react-native/community-cli-plugin/node_modules/which": {
       "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
@@ -5468,6 +5403,15 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@react-native/community-cli-plugin/node_modules/ws": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-6.2.3.tgz",
+      "integrity": "sha512-jmTjYU0j60B+vHey6TfR3Z7RD61z/hmxBS3VMSGIrroOWXQEneK1zNuotOUrGyBHQj0yrpsLHPWtigEFd13ndA==",
+      "license": "MIT",
+      "dependencies": {
+        "async-limiter": "~1.0.0"
       }
     },
     "node_modules/@react-native/debugger-frontend": {
@@ -5532,25 +5476,31 @@
       }
     },
     "node_modules/@react-native/gradle-plugin": {
-      "version": "0.74.85",
+      "version": "0.74.87",
+      "resolved": "https://registry.npmjs.org/@react-native/gradle-plugin/-/gradle-plugin-0.74.87.tgz",
+      "integrity": "sha512-T+VX0N1qP+U9V4oAtn7FTX7pfsoVkd1ocyw9swYXgJqU2fK7hC9famW7b3s3ZiufPGPr1VPJe2TVGtSopBjL6A==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@react-native/js-polyfills": {
-      "version": "0.74.85",
+      "version": "0.74.87",
+      "resolved": "https://registry.npmjs.org/@react-native/js-polyfills/-/js-polyfills-0.74.87.tgz",
+      "integrity": "sha512-M5Evdn76CuVEF0GsaXiGi95CBZ4IWubHqwXxV9vG9CC9kq0PSkoM2Pn7Lx7dgyp4vT7ccJ8a3IwHbe+5KJRnpw==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@react-native/metro-babel-transformer": {
-      "version": "0.74.85",
+      "version": "0.74.87",
+      "resolved": "https://registry.npmjs.org/@react-native/metro-babel-transformer/-/metro-babel-transformer-0.74.87.tgz",
+      "integrity": "sha512-UsJCO24sNax2NSPBmV1zLEVVNkS88kcgAiYrZHtYSwSjpl4WZ656tIeedBfiySdJ94Hr3kQmBYLipV5zk0NI1A==",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.20.0",
-        "@react-native/babel-preset": "0.74.85",
+        "@react-native/babel-preset": "0.74.87",
         "hermes-parser": "0.19.1",
         "nullthrows": "^1.1.1"
       },
@@ -5561,12 +5511,100 @@
         "@babel/core": "*"
       }
     },
-    "node_modules/@react-native/normalize-colors": {
-      "version": "0.74.84",
-      "license": "MIT"
+    "node_modules/@react-native/metro-babel-transformer/node_modules/@react-native/babel-plugin-codegen": {
+      "version": "0.74.87",
+      "resolved": "https://registry.npmjs.org/@react-native/babel-plugin-codegen/-/babel-plugin-codegen-0.74.87.tgz",
+      "integrity": "sha512-+vJYpMnENFrwtgvDfUj+CtVJRJuUnzAUYT0/Pb68Sq9RfcZ5xdcCuUgyf7JO+akW2VTBoJY427wkcxU30qrWWw==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-native/codegen": "0.74.87"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@react-native/metro-babel-transformer/node_modules/@react-native/babel-preset": {
+      "version": "0.74.87",
+      "resolved": "https://registry.npmjs.org/@react-native/babel-preset/-/babel-preset-0.74.87.tgz",
+      "integrity": "sha512-hyKpfqzN2nxZmYYJ0tQIHG99FQO0OWXp/gVggAfEUgiT+yNKas1C60LuofUsK7cd+2o9jrpqgqW4WzEDZoBlTg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.20.0",
+        "@babel/plugin-proposal-async-generator-functions": "^7.0.0",
+        "@babel/plugin-proposal-class-properties": "^7.18.0",
+        "@babel/plugin-proposal-export-default-from": "^7.0.0",
+        "@babel/plugin-proposal-logical-assignment-operators": "^7.18.0",
+        "@babel/plugin-proposal-nullish-coalescing-operator": "^7.18.0",
+        "@babel/plugin-proposal-numeric-separator": "^7.0.0",
+        "@babel/plugin-proposal-object-rest-spread": "^7.20.0",
+        "@babel/plugin-proposal-optional-catch-binding": "^7.0.0",
+        "@babel/plugin-proposal-optional-chaining": "^7.20.0",
+        "@babel/plugin-syntax-dynamic-import": "^7.8.0",
+        "@babel/plugin-syntax-export-default-from": "^7.0.0",
+        "@babel/plugin-syntax-flow": "^7.18.0",
+        "@babel/plugin-syntax-nullish-coalescing-operator": "^7.0.0",
+        "@babel/plugin-syntax-optional-chaining": "^7.0.0",
+        "@babel/plugin-transform-arrow-functions": "^7.0.0",
+        "@babel/plugin-transform-async-to-generator": "^7.20.0",
+        "@babel/plugin-transform-block-scoping": "^7.0.0",
+        "@babel/plugin-transform-classes": "^7.0.0",
+        "@babel/plugin-transform-computed-properties": "^7.0.0",
+        "@babel/plugin-transform-destructuring": "^7.20.0",
+        "@babel/plugin-transform-flow-strip-types": "^7.20.0",
+        "@babel/plugin-transform-function-name": "^7.0.0",
+        "@babel/plugin-transform-literals": "^7.0.0",
+        "@babel/plugin-transform-modules-commonjs": "^7.0.0",
+        "@babel/plugin-transform-named-capturing-groups-regex": "^7.0.0",
+        "@babel/plugin-transform-parameters": "^7.0.0",
+        "@babel/plugin-transform-private-methods": "^7.22.5",
+        "@babel/plugin-transform-private-property-in-object": "^7.22.11",
+        "@babel/plugin-transform-react-display-name": "^7.0.0",
+        "@babel/plugin-transform-react-jsx": "^7.0.0",
+        "@babel/plugin-transform-react-jsx-self": "^7.0.0",
+        "@babel/plugin-transform-react-jsx-source": "^7.0.0",
+        "@babel/plugin-transform-runtime": "^7.0.0",
+        "@babel/plugin-transform-shorthand-properties": "^7.0.0",
+        "@babel/plugin-transform-spread": "^7.0.0",
+        "@babel/plugin-transform-sticky-regex": "^7.0.0",
+        "@babel/plugin-transform-typescript": "^7.5.0",
+        "@babel/plugin-transform-unicode-regex": "^7.0.0",
+        "@babel/template": "^7.0.0",
+        "@react-native/babel-plugin-codegen": "0.74.87",
+        "babel-plugin-transform-flow-enums": "^0.0.2",
+        "react-refresh": "^0.14.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@babel/core": "*"
+      }
+    },
+    "node_modules/@react-native/metro-babel-transformer/node_modules/@react-native/codegen": {
+      "version": "0.74.87",
+      "resolved": "https://registry.npmjs.org/@react-native/codegen/-/codegen-0.74.87.tgz",
+      "integrity": "sha512-GMSYDiD+86zLKgMMgz9z0k6FxmRn+z6cimYZKkucW4soGbxWsbjUAZoZ56sJwt2FJ3XVRgXCrnOCgXoH/Bkhcg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.20.0",
+        "glob": "^7.1.1",
+        "hermes-parser": "0.19.1",
+        "invariant": "^2.2.4",
+        "jscodeshift": "^0.14.0",
+        "mkdirp": "^0.5.1",
+        "nullthrows": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@babel/preset-env": "^7.1.6"
+      }
     },
     "node_modules/@react-native/virtualized-lists": {
-      "version": "0.74.85",
+      "version": "0.74.87",
+      "resolved": "https://registry.npmjs.org/@react-native/virtualized-lists/-/virtualized-lists-0.74.87.tgz",
+      "integrity": "sha512-lsGxoFMb0lyK/MiplNKJpD+A1EoEUumkLrCjH4Ht+ZlG8S0BfCxmskLZ6qXn3BiDSkLjfjI/qyZ3pnxNBvkXpQ==",
       "license": "MIT",
       "dependencies": {
         "invariant": "^2.2.4",
@@ -5779,7 +5817,9 @@
       }
     },
     "node_modules/acorn": {
-      "version": "8.12.1",
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "license": "MIT",
       "bin": {
         "acorn": "bin/acorn"
@@ -5810,13 +5850,15 @@
       }
     },
     "node_modules/ajv": {
-      "version": "8.16.0",
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
         "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2",
-        "uri-js": "^4.4.1"
+        "require-from-string": "^2.0.2"
       },
       "funding": {
         "type": "github",
@@ -5872,6 +5914,8 @@
     },
     "node_modules/anymatch": {
       "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
       "license": "ISC",
       "dependencies": {
         "normalize-path": "^3.0.0",
@@ -5883,6 +5927,8 @@
     },
     "node_modules/anymatch/node_modules/picomatch": {
       "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
       "license": "MIT",
       "engines": {
         "node": ">=8.6"
@@ -6330,6 +6376,8 @@
     },
     "node_modules/bser": {
       "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/bser/-/bser-2.1.1.tgz",
+      "integrity": "sha512-gQxTNE/GAfIIrmHLUE3oJyp5FO6HRBfhjnw4/wMmA63ZGDJnWBmgY/lyQBpnDUkGmAhbSe39tx2d/iTOAfglwQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "node-int64": "^0.4.0"
@@ -6503,6 +6551,8 @@
     },
     "node_modules/camelcase": {
       "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+      "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -6623,6 +6673,8 @@
     },
     "node_modules/cliui": {
       "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
       "license": "ISC",
       "dependencies": {
         "string-width": "^4.2.0",
@@ -6635,6 +6687,8 @@
     },
     "node_modules/cliui/node_modules/strip-ansi": {
       "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -6662,14 +6716,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/color": {
-      "version": "3.2.1",
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^1.9.3",
-        "color-string": "^1.6.0"
-      }
-    },
     "node_modules/color-convert": {
       "version": "1.9.3",
       "license": "MIT",
@@ -6680,14 +6726,6 @@
     "node_modules/color-name": {
       "version": "1.1.3",
       "license": "MIT"
-    },
-    "node_modules/color-string": {
-      "version": "1.9.1",
-      "license": "MIT",
-      "dependencies": {
-        "color-name": "^1.0.0",
-        "simple-swizzle": "^0.2.2"
-      }
     },
     "node_modules/colorette": {
       "version": "1.4.0",
@@ -6807,6 +6845,8 @@
     },
     "node_modules/core-util-is": {
       "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
       "license": "MIT"
     },
     "node_modules/cosmiconfig": {
@@ -6862,13 +6902,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/css-in-js-utils": {
-      "version": "3.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "hyphenate-style-name": "^1.0.3"
       }
     },
     "node_modules/dag-map": {
@@ -7067,6 +7100,8 @@
     },
     "node_modules/denodeify": {
       "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/denodeify/-/denodeify-1.2.1.tgz",
+      "integrity": "sha512-KNTihKNmQENUZeKu5fzfpzRqR5S2VMp4gl9RFHiWzj9DfvYQPMJ6XHKNaQxaGCXwPk6y9yme3aUoaiAe+KX+vg==",
       "license": "MIT"
     },
     "node_modules/depd": {
@@ -7187,6 +7222,8 @@
     },
     "node_modules/error-stack-parser": {
       "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/error-stack-parser/-/error-stack-parser-2.1.4.tgz",
+      "integrity": "sha512-Sk5V6wVazPhq5MhpO+AUxJn5x7XSXGl1R93Vn7i+zS15KDVxQijejNCrz8340/2bgLBjR9GtEG8ZVKONDjcqGQ==",
       "license": "MIT",
       "dependencies": {
         "stackframe": "^1.3.4"
@@ -7423,7 +7460,9 @@
       }
     },
     "node_modules/expo-build-properties": {
-      "version": "0.12.3",
+      "version": "0.12.5",
+      "resolved": "https://registry.npmjs.org/expo-build-properties/-/expo-build-properties-0.12.5.tgz",
+      "integrity": "sha512-donC1le0PYfLKCPKRMGQoixuWuwDWCngzXSoQXUPsgHTDHQUKr8aw+lcWkTwZcItgNovcnk784I0dyfYDcxybA==",
       "license": "MIT",
       "dependencies": {
         "ajv": "^8.11.0",
@@ -7434,7 +7473,9 @@
       }
     },
     "node_modules/expo-build-properties/node_modules/semver": {
-      "version": "7.6.2",
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -7454,90 +7495,6 @@
         "expo": "*"
       }
     },
-    "node_modules/expo-dev-client": {
-      "version": "4.0.19",
-      "license": "MIT",
-      "dependencies": {
-        "expo-dev-launcher": "4.0.21",
-        "expo-dev-menu": "5.0.15",
-        "expo-dev-menu-interface": "1.8.3",
-        "expo-manifests": "~0.14.0",
-        "expo-updates-interface": "~0.16.2"
-      },
-      "peerDependencies": {
-        "expo": "*"
-      }
-    },
-    "node_modules/expo-dev-launcher": {
-      "version": "4.0.21",
-      "license": "MIT",
-      "dependencies": {
-        "ajv": "8.11.0",
-        "expo-dev-menu": "5.0.15",
-        "expo-manifests": "~0.14.0",
-        "resolve-from": "^5.0.0",
-        "semver": "^7.6.0"
-      },
-      "peerDependencies": {
-        "expo": "*"
-      }
-    },
-    "node_modules/expo-dev-launcher/node_modules/ajv": {
-      "version": "8.11.0",
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.1",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2",
-        "uri-js": "^4.2.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/expo-dev-launcher/node_modules/semver": {
-      "version": "7.6.2",
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/expo-dev-menu": {
-      "version": "5.0.15",
-      "license": "MIT",
-      "dependencies": {
-        "expo-dev-menu-interface": "1.8.3",
-        "semver": "^7.5.4"
-      },
-      "peerDependencies": {
-        "expo": "*"
-      }
-    },
-    "node_modules/expo-dev-menu-interface": {
-      "version": "1.8.3",
-      "license": "MIT",
-      "peerDependencies": {
-        "expo": "*"
-      }
-    },
-    "node_modules/expo-dev-menu/node_modules/semver": {
-      "version": "7.6.2",
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/expo-eas-client": {
-      "version": "0.12.0",
-      "license": "MIT"
-    },
     "node_modules/expo-file-system": {
       "version": "17.0.1",
       "license": "MIT",
@@ -7555,24 +7512,9 @@
         "expo": "*"
       }
     },
-    "node_modules/expo-json-utils": {
-      "version": "0.13.1",
-      "license": "MIT"
-    },
     "node_modules/expo-keep-awake": {
       "version": "13.0.2",
       "license": "MIT",
-      "peerDependencies": {
-        "expo": "*"
-      }
-    },
-    "node_modules/expo-manifests": {
-      "version": "0.14.3",
-      "license": "MIT",
-      "dependencies": {
-        "@expo/config": "~9.0.0",
-        "expo-json-utils": "~0.13.0"
-      },
       "peerDependencies": {
         "expo": "*"
       }
@@ -7686,119 +7628,9 @@
         "invariant": "^2.2.4"
       }
     },
-    "node_modules/expo-splash-screen": {
-      "version": "0.27.5",
-      "license": "MIT",
-      "dependencies": {
-        "@expo/prebuild-config": "7.0.6"
-      },
-      "peerDependencies": {
-        "expo": "*"
-      }
-    },
     "node_modules/expo-status-bar": {
       "version": "1.12.1",
       "license": "MIT"
-    },
-    "node_modules/expo-structured-headers": {
-      "version": "3.8.0",
-      "license": "MIT"
-    },
-    "node_modules/expo-updates": {
-      "version": "0.25.18",
-      "license": "MIT",
-      "dependencies": {
-        "@expo/code-signing-certificates": "0.0.5",
-        "@expo/config": "~9.0.0-beta.0",
-        "@expo/config-plugins": "~8.0.0-beta.0",
-        "@expo/fingerprint": "^0.10.0",
-        "@expo/spawn-async": "^1.7.2",
-        "arg": "4.1.0",
-        "chalk": "^4.1.2",
-        "expo-eas-client": "~0.12.0",
-        "expo-manifests": "~0.14.0",
-        "expo-structured-headers": "~3.8.0",
-        "expo-updates-interface": "~0.16.2",
-        "fast-glob": "^3.3.2",
-        "fbemitter": "^3.0.0",
-        "ignore": "^5.3.1",
-        "resolve-from": "^5.0.0"
-      },
-      "bin": {
-        "expo-updates": "bin/cli.js"
-      },
-      "peerDependencies": {
-        "expo": "*"
-      }
-    },
-    "node_modules/expo-updates-interface": {
-      "version": "0.16.2",
-      "license": "MIT",
-      "peerDependencies": {
-        "expo": "*"
-      }
-    },
-    "node_modules/expo-updates/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/expo-updates/node_modules/arg": {
-      "version": "4.1.0",
-      "license": "MIT"
-    },
-    "node_modules/expo-updates/node_modules/chalk": {
-      "version": "4.1.2",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/expo-updates/node_modules/color-convert": {
-      "version": "2.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/expo-updates/node_modules/color-name": {
-      "version": "1.1.4",
-      "license": "MIT"
-    },
-    "node_modules/expo-updates/node_modules/has-flag": {
-      "version": "4.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/expo-updates/node_modules/supports-color": {
-      "version": "7.2.0",
-      "license": "MIT",
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
     },
     "node_modules/expo/node_modules/@babel/code-frame": {
       "version": "7.10.4",
@@ -7852,8 +7684,16 @@
         "node": ">=10"
       }
     },
+    "node_modules/exponential-backoff": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/exponential-backoff/-/exponential-backoff-3.1.3.tgz",
+      "integrity": "sha512-ZgEeZXj30q+I0EN+CbSSpIyPaJ5HVQD18Z1m+u1FXbAeT94mr1zw50q4q6jiiC447Nl/YTcIYSAftiGqetwXCA==",
+      "license": "Apache-2.0"
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "license": "MIT"
     },
     "node_modules/fast-glob": {
@@ -7870,9 +7710,21 @@
         "node": ">=8.6.0"
       }
     },
-    "node_modules/fast-loops": {
-      "version": "1.1.4",
-      "license": "MIT"
+    "node_modules/fast-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/fast-xml-parser": {
       "version": "4.4.0",
@@ -7903,6 +7755,8 @@
     },
     "node_modules/fb-watchman": {
       "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.2.tgz",
+      "integrity": "sha512-p5161BqbuCaSnB8jIbzQHOlpgsPmK5rJVDfDKO91Axs5NC1uu3HRQm6wt9cd9/+GtQQIO53JdGXXoyDpTAsgYA==",
       "license": "Apache-2.0",
       "dependencies": {
         "bser": "2.1.1"
@@ -8155,6 +8009,9 @@
     },
     "node_modules/fsevents": {
       "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8453,13 +8310,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/hoist-non-react-statics": {
-      "version": "3.3.2",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "react-is": "^16.7.0"
-      }
-    },
     "node_modules/hosted-git-info": {
       "version": "3.0.8",
       "license": "ISC",
@@ -8523,10 +8373,6 @@
         "node": ">=10.17.0"
       }
     },
-    "node_modules/hyphenate-style-name": {
-      "version": "1.1.0",
-      "license": "BSD-3-Clause"
-    },
     "node_modules/ieee754": {
       "version": "1.2.1",
       "funding": [
@@ -8553,7 +8399,9 @@
       }
     },
     "node_modules/image-size": {
-      "version": "1.1.1",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/image-size/-/image-size-1.2.1.tgz",
+      "integrity": "sha512-rH+46sQJ2dlwfjfhCyNx5thzrv+dtmBIhPHk0zgRUukHzZ/kRueTJXoYYsclBaKcSMBWuGbOFXtioLpzTb5euw==",
       "license": "MIT",
       "dependencies": {
         "queue": "6.0.2"
@@ -8612,14 +8460,6 @@
     "node_modules/ini": {
       "version": "1.3.8",
       "license": "ISC"
-    },
-    "node_modules/inline-style-prefixer": {
-      "version": "6.0.4",
-      "license": "MIT",
-      "dependencies": {
-        "css-in-js-utils": "^3.1.0",
-        "fast-loops": "^1.1.3"
-      }
     },
     "node_modules/internal-ip": {
       "version": "4.3.0",
@@ -9007,6 +8847,8 @@
     },
     "node_modules/isarray": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
       "license": "MIT"
     },
     "node_modules/isexe": {
@@ -9053,6 +8895,8 @@
     },
     "node_modules/jest-get-type": {
       "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-29.6.3.tgz",
+      "integrity": "sha512-zrteXnqYxfQh7l5FHyL38jL39di8H8rHoecLH3JNxH3BwOrBsNeabdap5e0I23lD4HHI8W5VFBZqG4Eaq5LNcw==",
       "license": "MIT",
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
@@ -9257,6 +9101,8 @@
     },
     "node_modules/jest-validate": {
       "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-29.7.0.tgz",
+      "integrity": "sha512-ZB7wHqaRGVw/9hST/OuFUReG7M8vKeq0/J2egIGLdvjHCmYqGARhzXmtgi+gVeZ5uXFF219aOc3Ls2yLg27tkw==",
       "license": "MIT",
       "dependencies": {
         "@jest/types": "^29.6.3",
@@ -9272,6 +9118,8 @@
     },
     "node_modules/jest-validate/node_modules/ansi-styles": {
       "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -9285,6 +9133,8 @@
     },
     "node_modules/jest-validate/node_modules/chalk": {
       "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
@@ -9299,6 +9149,8 @@
     },
     "node_modules/jest-validate/node_modules/color-convert": {
       "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -9309,10 +9161,14 @@
     },
     "node_modules/jest-validate/node_modules/color-name": {
       "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "license": "MIT"
     },
     "node_modules/jest-validate/node_modules/has-flag": {
       "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -9320,6 +9176,8 @@
     },
     "node_modules/jest-validate/node_modules/pretty-format": {
       "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
+      "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
       "license": "MIT",
       "dependencies": {
         "@jest/schemas": "^29.6.3",
@@ -9332,6 +9190,8 @@
     },
     "node_modules/jest-validate/node_modules/pretty-format/node_modules/ansi-styles": {
       "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -9342,10 +9202,14 @@
     },
     "node_modules/jest-validate/node_modules/react-is": {
       "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
       "license": "MIT"
     },
     "node_modules/jest-validate/node_modules/supports-color": {
       "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
       "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
@@ -9356,6 +9220,8 @@
     },
     "node_modules/jest-worker": {
       "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-29.7.0.tgz",
+      "integrity": "sha512-eIz2msL/EzL9UFTFFx7jBTkeZfku0yUAyZZZmJ93H2TYEiroIx2PQjEXcwYtYl8zXCxb+PAmA2hLIt/6ZEkPHw==",
       "license": "MIT",
       "dependencies": {
         "@types/node": "*",
@@ -9369,6 +9235,8 @@
     },
     "node_modules/jest-worker/node_modules/has-flag": {
       "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -9376,6 +9244,8 @@
     },
     "node_modules/jest-worker/node_modules/supports-color": {
       "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
       "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
@@ -9560,6 +9430,8 @@
     },
     "node_modules/json-schema-traverse": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "license": "MIT"
     },
     "node_modules/json5": {
@@ -9595,6 +9467,8 @@
     },
     "node_modules/leven": {
       "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
+      "integrity": "sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==",
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -9688,6 +9562,8 @@
     },
     "node_modules/lodash.throttle": {
       "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.throttle/-/lodash.throttle-4.1.1.tgz",
+      "integrity": "sha512-wIkUCfVKpVsWo3JSZlc+8MB5it+2AN5W8J7YVMST30UrvcQNZ1Okbj+rbVniijTWE6FGYy4XJq/rHkas8qJMLQ==",
       "license": "MIT"
     },
     "node_modules/log-symbols": {
@@ -9893,6 +9769,8 @@
     },
     "node_modules/makeerror": {
       "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.12.tgz",
+      "integrity": "sha512-JmqCvUhmt43madlpFzG4BQzG2Z3m6tvQDNKdClZnO3VbIudJYmxsT0FNJMeiB2+JTSlTQTSbU8QdesVmwJcmLg==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "tmpl": "1.0.5"
@@ -9948,7 +9826,9 @@
       }
     },
     "node_modules/metro": {
-      "version": "0.80.9",
+      "version": "0.80.12",
+      "resolved": "https://registry.npmjs.org/metro/-/metro-0.80.12.tgz",
+      "integrity": "sha512-1UsH5FzJd9quUsD1qY+zUG4JY3jo3YEMxbMYH9jT6NK3j4iORhlwTK8fYTfAUBhDKjgLfKjAh7aoazNE23oIRA==",
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.0.0",
@@ -9965,34 +9845,33 @@
         "debug": "^2.2.0",
         "denodeify": "^1.2.1",
         "error-stack-parser": "^2.0.6",
+        "flow-enums-runtime": "^0.0.6",
         "graceful-fs": "^4.2.4",
-        "hermes-parser": "0.20.1",
+        "hermes-parser": "0.23.1",
         "image-size": "^1.0.2",
         "invariant": "^2.2.4",
         "jest-worker": "^29.6.3",
         "jsc-safe-url": "^0.2.2",
         "lodash.throttle": "^4.1.1",
-        "metro-babel-transformer": "0.80.9",
-        "metro-cache": "0.80.9",
-        "metro-cache-key": "0.80.9",
-        "metro-config": "0.80.9",
-        "metro-core": "0.80.9",
-        "metro-file-map": "0.80.9",
-        "metro-resolver": "0.80.9",
-        "metro-runtime": "0.80.9",
-        "metro-source-map": "0.80.9",
-        "metro-symbolicate": "0.80.9",
-        "metro-transform-plugins": "0.80.9",
-        "metro-transform-worker": "0.80.9",
+        "metro-babel-transformer": "0.80.12",
+        "metro-cache": "0.80.12",
+        "metro-cache-key": "0.80.12",
+        "metro-config": "0.80.12",
+        "metro-core": "0.80.12",
+        "metro-file-map": "0.80.12",
+        "metro-resolver": "0.80.12",
+        "metro-runtime": "0.80.12",
+        "metro-source-map": "0.80.12",
+        "metro-symbolicate": "0.80.12",
+        "metro-transform-plugins": "0.80.12",
+        "metro-transform-worker": "0.80.12",
         "mime-types": "^2.1.27",
-        "node-fetch": "^2.2.0",
         "nullthrows": "^1.1.1",
-        "rimraf": "^3.0.2",
         "serialize-error": "^2.1.0",
         "source-map": "^0.5.6",
         "strip-ansi": "^6.0.0",
         "throat": "^5.0.0",
-        "ws": "^7.5.1",
+        "ws": "^7.5.10",
         "yargs": "^17.6.2"
       },
       "bin": {
@@ -10003,11 +9882,14 @@
       }
     },
     "node_modules/metro-babel-transformer": {
-      "version": "0.80.9",
+      "version": "0.80.12",
+      "resolved": "https://registry.npmjs.org/metro-babel-transformer/-/metro-babel-transformer-0.80.12.tgz",
+      "integrity": "sha512-YZziRs0MgA3pzCkkvOoQRXjIoVjvrpi/yRlJnObyIvMP6lFdtyG4nUGIwGY9VXnBvxmXD6mPY2e+NSw6JAyiRg==",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.20.0",
-        "hermes-parser": "0.20.1",
+        "flow-enums-runtime": "^0.0.6",
+        "hermes-parser": "0.23.1",
         "nullthrows": "^1.1.1"
       },
       "engines": {
@@ -10015,81 +9897,89 @@
       }
     },
     "node_modules/metro-babel-transformer/node_modules/hermes-estree": {
-      "version": "0.20.1",
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.23.1.tgz",
+      "integrity": "sha512-eT5MU3f5aVhTqsfIReZ6n41X5sYn4IdQL0nvz6yO+MMlPxw49aSARHLg/MSehQftyjnrE8X6bYregzSumqc6cg==",
       "license": "MIT"
     },
     "node_modules/metro-babel-transformer/node_modules/hermes-parser": {
-      "version": "0.20.1",
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.23.1.tgz",
+      "integrity": "sha512-oxl5h2DkFW83hT4DAUJorpah8ou4yvmweUzLJmmr6YV2cezduCdlil1AvU/a/xSsAFo4WUcNA4GoV5Bvq6JffA==",
       "license": "MIT",
       "dependencies": {
-        "hermes-estree": "0.20.1"
+        "hermes-estree": "0.23.1"
       }
     },
     "node_modules/metro-cache": {
-      "version": "0.80.9",
+      "version": "0.80.12",
+      "resolved": "https://registry.npmjs.org/metro-cache/-/metro-cache-0.80.12.tgz",
+      "integrity": "sha512-p5kNHh2KJ0pbQI/H7ZBPCEwkyNcSz7OUkslzsiIWBMPQGFJ/xArMwkV7I+GJcWh+b4m6zbLxE5fk6fqbVK1xGA==",
       "license": "MIT",
       "dependencies": {
-        "metro-core": "0.80.9",
-        "rimraf": "^3.0.2"
+        "exponential-backoff": "^3.1.1",
+        "flow-enums-runtime": "^0.0.6",
+        "metro-core": "0.80.12"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/metro-cache-key": {
-      "version": "0.80.9",
+      "version": "0.80.12",
+      "resolved": "https://registry.npmjs.org/metro-cache-key/-/metro-cache-key-0.80.12.tgz",
+      "integrity": "sha512-o4BspKnugg/pE45ei0LGHVuBJXwRgruW7oSFAeSZvBKA/sGr0UhOGY3uycOgWInnS3v5yTTfiBA9lHlNRhsvGA==",
       "license": "MIT",
+      "dependencies": {
+        "flow-enums-runtime": "^0.0.6"
+      },
       "engines": {
         "node": ">=18"
       }
     },
-    "node_modules/metro-cache/node_modules/rimraf": {
-      "version": "3.0.2",
-      "license": "ISC",
-      "dependencies": {
-        "glob": "^7.1.3"
-      },
-      "bin": {
-        "rimraf": "bin.js"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/metro-config": {
-      "version": "0.80.9",
+      "version": "0.80.12",
+      "resolved": "https://registry.npmjs.org/metro-config/-/metro-config-0.80.12.tgz",
+      "integrity": "sha512-4rwOWwrhm62LjB12ytiuR5NgK1ZBNr24/He8mqCsC+HXZ+ATbrewLNztzbAZHtFsrxP4D4GLTGgh96pCpYLSAQ==",
       "license": "MIT",
       "dependencies": {
         "connect": "^3.6.5",
         "cosmiconfig": "^5.0.5",
+        "flow-enums-runtime": "^0.0.6",
         "jest-validate": "^29.6.3",
-        "metro": "0.80.9",
-        "metro-cache": "0.80.9",
-        "metro-core": "0.80.9",
-        "metro-runtime": "0.80.9"
+        "metro": "0.80.12",
+        "metro-cache": "0.80.12",
+        "metro-core": "0.80.12",
+        "metro-runtime": "0.80.12"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/metro-core": {
-      "version": "0.80.9",
+      "version": "0.80.12",
+      "resolved": "https://registry.npmjs.org/metro-core/-/metro-core-0.80.12.tgz",
+      "integrity": "sha512-QqdJ/yAK+IpPs2HU/h5v2pKEdANBagSsc6DRSjnwSyJsCoHlmyJKCaCJ7KhWGx+N4OHxh37hoA8fc2CuZbx0Fw==",
       "license": "MIT",
       "dependencies": {
+        "flow-enums-runtime": "^0.0.6",
         "lodash.throttle": "^4.1.1",
-        "metro-resolver": "0.80.9"
+        "metro-resolver": "0.80.12"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/metro-file-map": {
-      "version": "0.80.9",
+      "version": "0.80.12",
+      "resolved": "https://registry.npmjs.org/metro-file-map/-/metro-file-map-0.80.12.tgz",
+      "integrity": "sha512-sYdemWSlk66bWzW2wp79kcPMzwuG32x1ZF3otI0QZTmrnTaaTiGyhE66P1z6KR4n2Eu5QXiABa6EWbAQv0r8bw==",
       "license": "MIT",
       "dependencies": {
         "anymatch": "^3.0.3",
         "debug": "^2.2.0",
         "fb-watchman": "^2.0.0",
+        "flow-enums-runtime": "^0.0.6",
         "graceful-fs": "^4.2.4",
         "invariant": "^2.2.4",
         "jest-worker": "^29.6.3",
@@ -10107,6 +9997,8 @@
     },
     "node_modules/metro-file-map/node_modules/debug": {
       "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
       "license": "MIT",
       "dependencies": {
         "ms": "2.0.0"
@@ -10114,12 +10006,17 @@
     },
     "node_modules/metro-file-map/node_modules/ms": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "license": "MIT"
     },
     "node_modules/metro-minify-terser": {
-      "version": "0.80.9",
+      "version": "0.80.12",
+      "resolved": "https://registry.npmjs.org/metro-minify-terser/-/metro-minify-terser-0.80.12.tgz",
+      "integrity": "sha512-muWzUw3y5k+9083ZoX9VaJLWEV2Jcgi+Oan0Mmb/fBNMPqP9xVDuy4pOMn/HOiGndgfh/MK7s4bsjkyLJKMnXQ==",
       "license": "MIT",
       "dependencies": {
+        "flow-enums-runtime": "^0.0.6",
         "terser": "^5.15.0"
       },
       "engines": {
@@ -10127,32 +10024,43 @@
       }
     },
     "node_modules/metro-resolver": {
-      "version": "0.80.9",
+      "version": "0.80.12",
+      "resolved": "https://registry.npmjs.org/metro-resolver/-/metro-resolver-0.80.12.tgz",
+      "integrity": "sha512-PR24gYRZnYHM3xT9pg6BdbrGbM/Cu1TcyIFBVlAk7qDAuHkUNQ1nMzWumWs+kwSvtd9eZGzHoucGJpTUEeLZAw==",
       "license": "MIT",
+      "dependencies": {
+        "flow-enums-runtime": "^0.0.6"
+      },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/metro-runtime": {
-      "version": "0.80.9",
+      "version": "0.80.12",
+      "resolved": "https://registry.npmjs.org/metro-runtime/-/metro-runtime-0.80.12.tgz",
+      "integrity": "sha512-LIx7+92p5rpI0i6iB4S4GBvvLxStNt6fF0oPMaUd1Weku7jZdfkCZzmrtDD9CSQ6EPb0T9NUZoyXIxlBa3wOCw==",
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.0.0"
+        "@babel/runtime": "^7.25.0",
+        "flow-enums-runtime": "^0.0.6"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/metro-source-map": {
-      "version": "0.80.9",
+      "version": "0.80.12",
+      "resolved": "https://registry.npmjs.org/metro-source-map/-/metro-source-map-0.80.12.tgz",
+      "integrity": "sha512-o+AXmE7hpvM8r8MKsx7TI21/eerYYy2DCDkWfoBkv+jNkl61khvDHlQn0cXZa6lrcNZiZkl9oHSMcwLLIrFmpw==",
       "license": "MIT",
       "dependencies": {
         "@babel/traverse": "^7.20.0",
         "@babel/types": "^7.20.0",
+        "flow-enums-runtime": "^0.0.6",
         "invariant": "^2.2.4",
-        "metro-symbolicate": "0.80.9",
+        "metro-symbolicate": "0.80.12",
         "nullthrows": "^1.1.1",
-        "ob1": "0.80.9",
+        "ob1": "0.80.12",
         "source-map": "^0.5.6",
         "vlq": "^1.0.0"
       },
@@ -10162,17 +10070,22 @@
     },
     "node_modules/metro-source-map/node_modules/source-map": {
       "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+      "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/metro-symbolicate": {
-      "version": "0.80.9",
+      "version": "0.80.12",
+      "resolved": "https://registry.npmjs.org/metro-symbolicate/-/metro-symbolicate-0.80.12.tgz",
+      "integrity": "sha512-/dIpNdHksXkGHZXARZpL7doUzHqSNxgQ8+kQGxwpJuHnDhGkENxB5PS2QBaTDdEcmyTMjS53CN1rl9n1gR6fmw==",
       "license": "MIT",
       "dependencies": {
+        "flow-enums-runtime": "^0.0.6",
         "invariant": "^2.2.4",
-        "metro-source-map": "0.80.9",
+        "metro-source-map": "0.80.12",
         "nullthrows": "^1.1.1",
         "source-map": "^0.5.6",
         "through2": "^2.0.1",
@@ -10187,19 +10100,24 @@
     },
     "node_modules/metro-symbolicate/node_modules/source-map": {
       "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+      "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/metro-transform-plugins": {
-      "version": "0.80.9",
+      "version": "0.80.12",
+      "resolved": "https://registry.npmjs.org/metro-transform-plugins/-/metro-transform-plugins-0.80.12.tgz",
+      "integrity": "sha512-WQWp00AcZvXuQdbjQbx1LzFR31IInlkCDYJNRs6gtEtAyhwpMMlL2KcHmdY+wjDO9RPcliZ+Xl1riOuBecVlPA==",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.20.0",
         "@babel/generator": "^7.20.0",
         "@babel/template": "^7.0.0",
         "@babel/traverse": "^7.20.0",
+        "flow-enums-runtime": "^0.0.6",
         "nullthrows": "^1.1.1"
       },
       "engines": {
@@ -10207,20 +10125,23 @@
       }
     },
     "node_modules/metro-transform-worker": {
-      "version": "0.80.9",
+      "version": "0.80.12",
+      "resolved": "https://registry.npmjs.org/metro-transform-worker/-/metro-transform-worker-0.80.12.tgz",
+      "integrity": "sha512-KAPFN1y3eVqEbKLx1I8WOarHPqDMUa8WelWxaJCNKO/yHCP26zELeqTJvhsQup+8uwB6EYi/sp0b6TGoh6lOEA==",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.20.0",
         "@babel/generator": "^7.20.0",
         "@babel/parser": "^7.20.0",
         "@babel/types": "^7.20.0",
-        "metro": "0.80.9",
-        "metro-babel-transformer": "0.80.9",
-        "metro-cache": "0.80.9",
-        "metro-cache-key": "0.80.9",
-        "metro-minify-terser": "0.80.9",
-        "metro-source-map": "0.80.9",
-        "metro-transform-plugins": "0.80.9",
+        "flow-enums-runtime": "^0.0.6",
+        "metro": "0.80.12",
+        "metro-babel-transformer": "0.80.12",
+        "metro-cache": "0.80.12",
+        "metro-cache-key": "0.80.12",
+        "metro-minify-terser": "0.80.12",
+        "metro-source-map": "0.80.12",
+        "metro-transform-plugins": "0.80.12",
         "nullthrows": "^1.1.1"
       },
       "engines": {
@@ -10229,6 +10150,8 @@
     },
     "node_modules/metro/node_modules/ansi-styles": {
       "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -10242,6 +10165,8 @@
     },
     "node_modules/metro/node_modules/chalk": {
       "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
@@ -10256,10 +10181,14 @@
     },
     "node_modules/metro/node_modules/ci-info": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
+      "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
       "license": "MIT"
     },
     "node_modules/metro/node_modules/color-convert": {
       "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -10270,10 +10199,14 @@
     },
     "node_modules/metro/node_modules/color-name": {
       "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "license": "MIT"
     },
     "node_modules/metro/node_modules/debug": {
       "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
       "license": "MIT",
       "dependencies": {
         "ms": "2.0.0"
@@ -10281,41 +10214,38 @@
     },
     "node_modules/metro/node_modules/has-flag": {
       "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
       "license": "MIT",
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/metro/node_modules/hermes-estree": {
-      "version": "0.20.1",
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.23.1.tgz",
+      "integrity": "sha512-eT5MU3f5aVhTqsfIReZ6n41X5sYn4IdQL0nvz6yO+MMlPxw49aSARHLg/MSehQftyjnrE8X6bYregzSumqc6cg==",
       "license": "MIT"
     },
     "node_modules/metro/node_modules/hermes-parser": {
-      "version": "0.20.1",
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.23.1.tgz",
+      "integrity": "sha512-oxl5h2DkFW83hT4DAUJorpah8ou4yvmweUzLJmmr6YV2cezduCdlil1AvU/a/xSsAFo4WUcNA4GoV5Bvq6JffA==",
       "license": "MIT",
       "dependencies": {
-        "hermes-estree": "0.20.1"
+        "hermes-estree": "0.23.1"
       }
     },
     "node_modules/metro/node_modules/ms": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "license": "MIT"
-    },
-    "node_modules/metro/node_modules/rimraf": {
-      "version": "3.0.2",
-      "license": "ISC",
-      "dependencies": {
-        "glob": "^7.1.3"
-      },
-      "bin": {
-        "rimraf": "bin.js"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
     },
     "node_modules/metro/node_modules/source-map": {
       "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+      "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -10323,6 +10253,8 @@
     },
     "node_modules/metro/node_modules/strip-ansi": {
       "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -10333,6 +10265,8 @@
     },
     "node_modules/metro/node_modules/supports-color": {
       "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
       "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
@@ -10343,6 +10277,8 @@
     },
     "node_modules/metro/node_modules/ws": {
       "version": "7.5.10",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
+      "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
       "license": "MIT",
       "engines": {
         "node": ">=8.3.0"
@@ -10636,6 +10572,8 @@
     },
     "node_modules/node-abort-controller": {
       "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/node-abort-controller/-/node-abort-controller-3.1.1.tgz",
+      "integrity": "sha512-AGK2yQKIjRuqnc6VkX2Xj5d+QW8xZ87pa1UK6yA6ouUyuxfHuMP6umE5QK7UmTeOAymo+Zx1Fxiuw9rVx8taHQ==",
       "license": "MIT"
     },
     "node_modules/node-dir": {
@@ -10675,6 +10613,8 @@
     },
     "node_modules/node-int64": {
       "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
+      "integrity": "sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==",
       "license": "MIT"
     },
     "node_modules/node-releases": {
@@ -10694,6 +10634,8 @@
     },
     "node_modules/normalize-path": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -10731,8 +10673,13 @@
       "license": "MIT"
     },
     "node_modules/ob1": {
-      "version": "0.80.9",
+      "version": "0.80.12",
+      "resolved": "https://registry.npmjs.org/ob1/-/ob1-0.80.12.tgz",
+      "integrity": "sha512-VMArClVT6LkhUGpnuEoBuyjG9rzUyEzg4PDkav6wK1cLhOK02gPCYFxoiB4mqVnrMhDpIzJcrGNAMVi9P+hXrw==",
       "license": "MIT",
+      "dependencies": {
+        "flow-enums-runtime": "^0.0.6"
+      },
       "engines": {
         "node": ">=18"
       }
@@ -11213,10 +11160,6 @@
         "node": "^10 || ^12 || >=14"
       }
     },
-    "node_modules/postcss-value-parser": {
-      "version": "4.2.0",
-      "license": "MIT"
-    },
     "node_modules/pretty-bytes": {
       "version": "5.6.0",
       "license": "MIT",
@@ -11325,6 +11268,8 @@
     },
     "node_modules/process-nextick-args": {
       "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
       "license": "MIT"
     },
     "node_modules/progress": {
@@ -11384,6 +11329,9 @@
     },
     "node_modules/querystring": {
       "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.1.tgz",
+      "integrity": "sha512-wkvS7mL/JMugcup3/rMitHmd9ecIGd2lhFhK9N3UUQ450h66d1r3Y9nvXzQAW1Lq+wyx61k/1pfKS5KuKiyEbg==",
+      "deprecated": "The querystring API is considered Legacy. new code should use the URLSearchParams API instead.",
       "license": "MIT",
       "engines": {
         "node": ">=0.4.x"
@@ -11391,6 +11339,8 @@
     },
     "node_modules/queue": {
       "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/queue/-/queue-6.0.2.tgz",
+      "integrity": "sha512-iHZWu+q3IdFZFX36ro/lKBkSvfkztY5Y7HMiPlOUjhupPcG2JMfst2KKEpu5XndviX/3UhFbRngUPNKtgvtZiA==",
       "license": "MIT",
       "dependencies": {
         "inherits": "~2.0.3"
@@ -11471,36 +11421,27 @@
         }
       }
     },
-    "node_modules/react-dom": {
-      "version": "18.2.0",
-      "license": "MIT",
-      "dependencies": {
-        "loose-envify": "^1.1.0",
-        "scheduler": "^0.23.0"
-      },
-      "peerDependencies": {
-        "react": "^18.2.0"
-      }
-    },
     "node_modules/react-is": {
       "version": "16.13.1",
       "license": "MIT"
     },
     "node_modules/react-native": {
-      "version": "0.74.3",
+      "version": "0.74.5",
+      "resolved": "https://registry.npmjs.org/react-native/-/react-native-0.74.5.tgz",
+      "integrity": "sha512-Bgg2WvxaGODukJMTZFTZBNMKVaROHLwSb8VAGEdrlvKwfb1hHg/3aXTUICYk7dwgAnb+INbGMwnF8yeAgIUmqw==",
       "license": "MIT",
       "dependencies": {
         "@jest/create-cache-key-function": "^29.6.3",
         "@react-native-community/cli": "13.6.9",
         "@react-native-community/cli-platform-android": "13.6.9",
         "@react-native-community/cli-platform-ios": "13.6.9",
-        "@react-native/assets-registry": "0.74.85",
-        "@react-native/codegen": "0.74.85",
-        "@react-native/community-cli-plugin": "0.74.85",
-        "@react-native/gradle-plugin": "0.74.85",
-        "@react-native/js-polyfills": "0.74.85",
-        "@react-native/normalize-colors": "0.74.85",
-        "@react-native/virtualized-lists": "0.74.85",
+        "@react-native/assets-registry": "0.74.87",
+        "@react-native/codegen": "0.74.87",
+        "@react-native/community-cli-plugin": "0.74.87",
+        "@react-native/gradle-plugin": "0.74.87",
+        "@react-native/js-polyfills": "0.74.87",
+        "@react-native/normalize-colors": "0.74.87",
+        "@react-native/virtualized-lists": "0.74.87",
         "abort-controller": "^3.0.0",
         "anser": "^1.4.9",
         "ansi-regex": "^5.0.0",
@@ -11544,116 +11485,31 @@
         }
       }
     },
-    "node_modules/react-native-iphone-x-helper": {
-      "version": "1.3.1",
-      "license": "MIT",
-      "peerDependencies": {
-        "react-native": ">=0.42.0"
-      }
-    },
-    "node_modules/react-native-paper": {
-      "version": "4.12.8",
+    "node_modules/react-native/node_modules/@react-native/codegen": {
+      "version": "0.74.87",
+      "resolved": "https://registry.npmjs.org/@react-native/codegen/-/codegen-0.74.87.tgz",
+      "integrity": "sha512-GMSYDiD+86zLKgMMgz9z0k6FxmRn+z6cimYZKkucW4soGbxWsbjUAZoZ56sJwt2FJ3XVRgXCrnOCgXoH/Bkhcg==",
       "license": "MIT",
       "dependencies": {
-        "@callstack/react-theme-provider": "^3.0.7",
-        "color": "^3.1.2",
-        "react-native-iphone-x-helper": "^1.3.1"
-      },
-      "peerDependencies": {
-        "react": "*",
-        "react-native": "*",
-        "react-native-vector-icons": "*"
-      }
-    },
-    "node_modules/react-native-vector-icons": {
-      "version": "10.1.0",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "prop-types": "^15.7.2",
-        "yargs": "^16.1.1"
-      },
-      "bin": {
-        "fa-upgrade.sh": "bin/fa-upgrade.sh",
-        "fa5-upgrade": "bin/fa5-upgrade.sh",
-        "fa6-upgrade": "bin/fa6-upgrade.sh",
-        "generate-icon": "bin/generate-icon.js"
-      }
-    },
-    "node_modules/react-native-vector-icons/node_modules/cliui": {
-      "version": "7.0.4",
-      "license": "ISC",
-      "peer": true,
-      "dependencies": {
-        "string-width": "^4.2.0",
-        "strip-ansi": "^6.0.0",
-        "wrap-ansi": "^7.0.0"
-      }
-    },
-    "node_modules/react-native-vector-icons/node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
+        "@babel/parser": "^7.20.0",
+        "glob": "^7.1.1",
+        "hermes-parser": "0.19.1",
+        "invariant": "^2.2.4",
+        "jscodeshift": "^0.14.0",
+        "mkdirp": "^0.5.1",
+        "nullthrows": "^1.1.1"
       },
       "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/react-native-vector-icons/node_modules/yargs": {
-      "version": "16.2.0",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "cliui": "^7.0.2",
-        "escalade": "^3.1.1",
-        "get-caller-file": "^2.0.5",
-        "require-directory": "^2.1.1",
-        "string-width": "^4.2.0",
-        "y18n": "^5.0.5",
-        "yargs-parser": "^20.2.2"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/react-native-vector-icons/node_modules/yargs-parser": {
-      "version": "20.2.9",
-      "license": "ISC",
-      "peer": true,
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/react-native-web": {
-      "version": "0.19.12",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.18.6",
-        "@react-native/normalize-colors": "^0.74.1",
-        "fbjs": "^3.0.4",
-        "inline-style-prefixer": "^6.0.1",
-        "memoize-one": "^6.0.0",
-        "nullthrows": "^1.1.1",
-        "postcss-value-parser": "^4.2.0",
-        "styleq": "^0.1.3"
+        "node": ">=18"
       },
       "peerDependencies": {
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0"
+        "@babel/preset-env": "^7.1.6"
       }
-    },
-    "node_modules/react-native-web/node_modules/@react-native/normalize-colors": {
-      "version": "0.74.85",
-      "license": "MIT"
-    },
-    "node_modules/react-native-web/node_modules/memoize-one": {
-      "version": "6.0.0",
-      "license": "MIT"
     },
     "node_modules/react-native/node_modules/@react-native/normalize-colors": {
-      "version": "0.74.85",
+      "version": "0.74.87",
+      "resolved": "https://registry.npmjs.org/@react-native/normalize-colors/-/normalize-colors-0.74.87.tgz",
+      "integrity": "sha512-Xh7Nyk/MPefkb0Itl5Z+3oOobeG9lfLb7ZOY2DKpFnoCE1TzBmib9vMNdFaLdSxLIP+Ec6icgKtdzYg8QUPYzA==",
       "license": "MIT"
     },
     "node_modules/react-native/node_modules/ansi-styles": {
@@ -11759,6 +11615,8 @@
     },
     "node_modules/readable-stream": {
       "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
       "license": "MIT",
       "dependencies": {
         "core-util-is": "~1.0.0",
@@ -11772,6 +11630,8 @@
     },
     "node_modules/readline": {
       "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/readline/-/readline-1.3.0.tgz",
+      "integrity": "sha512-k2d6ACCkiNYz222Fs/iNze30rRJ1iIicW7JuX/7/cozvih6YCkFZH+J6mAFDVgv0dRBaAyr4jDqC95R2y4IADg==",
       "license": "BSD"
     },
     "node_modules/recast": {
@@ -11807,10 +11667,6 @@
       "engines": {
         "node": ">=4"
       }
-    },
-    "node_modules/regenerator-runtime": {
-      "version": "0.14.1",
-      "license": "MIT"
     },
     "node_modules/regenerator-transform": {
       "version": "0.15.2",
@@ -12034,13 +11890,6 @@
       "version": "1.4.1",
       "license": "ISC"
     },
-    "node_modules/scheduler": {
-      "version": "0.23.2",
-      "license": "MIT",
-      "dependencies": {
-        "loose-envify": "^1.1.0"
-      }
-    },
     "node_modules/selfsigned": {
       "version": "2.4.1",
       "license": "MIT",
@@ -12125,6 +11974,8 @@
     },
     "node_modules/serialize-error": {
       "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-2.1.0.tgz",
+      "integrity": "sha512-ghgmKt5o4Tly5yEG/UJp8qTd0AN7Xalw4XBtDEKP655B699qMEtra1WlXeE6WIvdEG481JvRxULKsInq/iNysw==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -12256,17 +12107,6 @@
         "node": ">= 5.10.0"
       }
     },
-    "node_modules/simple-swizzle": {
-      "version": "0.2.2",
-      "license": "MIT",
-      "dependencies": {
-        "is-arrayish": "^0.3.1"
-      }
-    },
-    "node_modules/simple-swizzle/node_modules/is-arrayish": {
-      "version": "0.3.2",
-      "license": "MIT"
-    },
     "node_modules/sisteransi": {
       "version": "1.0.5",
       "license": "MIT"
@@ -12369,6 +12209,8 @@
     },
     "node_modules/stackframe": {
       "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/stackframe/-/stackframe-1.3.4.tgz",
+      "integrity": "sha512-oeVtt7eWQS+Na6F//S4kJ2K2VbRlS9D43mAlMyVpVWovy9o+jfgH8O9agzANzaiLjclA0oYzUXEM4PurhSUChw==",
       "license": "MIT"
     },
     "node_modules/stacktrace-parser": {
@@ -12566,10 +12408,6 @@
     },
     "node_modules/structured-headers": {
       "version": "0.4.1",
-      "license": "MIT"
-    },
-    "node_modules/styleq": {
-      "version": "0.1.3",
       "license": "MIT"
     },
     "node_modules/sucrase": {
@@ -12804,11 +12642,13 @@
       }
     },
     "node_modules/terser": {
-      "version": "5.31.1",
+      "version": "5.46.0",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.46.0.tgz",
+      "integrity": "sha512-jTwoImyr/QbOWFFso3YoU3ik0jBBDJ6JTOQiy/J2YxVJdZCc+5u7skhNwiOR3FQIygFqVUPHl7qbbxtjW2K3Qg==",
       "license": "BSD-2-Clause",
       "dependencies": {
         "@jridgewell/source-map": "^0.3.3",
-        "acorn": "^8.8.2",
+        "acorn": "^8.15.0",
         "commander": "^2.20.0",
         "source-map-support": "~0.5.20"
       },
@@ -12821,6 +12661,8 @@
     },
     "node_modules/terser/node_modules/commander": {
       "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
       "license": "MIT"
     },
     "node_modules/text-table": {
@@ -12846,6 +12688,8 @@
     },
     "node_modules/throat": {
       "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/throat/-/throat-5.0.0.tgz",
+      "integrity": "sha512-fcwX4mndzpLQKBS1DVYhGAcYaYt7vsHNIvQV+WXMvnow5cgjPphq5CaayLaGsjRdSCKZFNGt7/GYAuXaNOiYCA==",
       "license": "MIT"
     },
     "node_modules/through": {
@@ -12854,6 +12698,8 @@
     },
     "node_modules/through2": {
       "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
+      "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
       "license": "MIT",
       "dependencies": {
         "readable-stream": "~2.3.6",
@@ -12872,6 +12718,8 @@
     },
     "node_modules/tmpl": {
       "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
+      "integrity": "sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==",
       "license": "BSD-3-Clause"
     },
     "node_modules/to-fast-properties": {
@@ -13174,13 +13022,6 @@
         "browserslist": ">= 4.21.0"
       }
     },
-    "node_modules/uri-js": {
-      "version": "4.4.1",
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "punycode": "^2.1.0"
-      }
-    },
     "node_modules/url-join": {
       "version": "4.0.0",
       "license": "MIT"
@@ -13222,10 +13063,14 @@
     },
     "node_modules/vlq": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/vlq/-/vlq-1.0.1.tgz",
+      "integrity": "sha512-gQpnTgkubC6hQgdIcRdYGDSDc+SaujOdyesZQMv6JlfQee/9Mp0Qhnys6WxDWvQnL5WZdT7o2Ul187aSt0Rq+w==",
       "license": "MIT"
     },
     "node_modules/walker": {
       "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/walker/-/walker-1.0.8.tgz",
+      "integrity": "sha512-ts/8E8l5b7kY0vlWLewOkDXMmPdLcVV4GmOQLyxuSswIJsweeFZtAsMF7k1Nszz+TYBQrlYRmzOnr398y1JemQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "makeerror": "1.0.12"
@@ -13504,6 +13349,8 @@
     },
     "node_modules/xtend": {
       "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
       "license": "MIT",
       "engines": {
         "node": ">=0.4"
@@ -13532,6 +13379,8 @@
     },
     "node_modules/yargs": {
       "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
       "license": "MIT",
       "dependencies": {
         "cliui": "^8.0.1",
@@ -13548,6 +13397,8 @@
     },
     "node_modules/yargs-parser": {
       "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
       "license": "ISC",
       "engines": {
         "node": ">=12"

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build:android": "eas build --platform android --profile preview"
   },
   "dependencies": {
-    "@maniac-tech/react-native-expo-read-sms": "^9.1.1",
+    "@maniac-tech/react-native-expo-read-sms": "^9.1.2",
     "expo": "^51.0.0",
     "expo-dev-client": "~4.0.19",
     "expo-splash-screen": "~0.27.5",

--- a/package.json
+++ b/package.json
@@ -1,30 +1,22 @@
 {
-  "name": "exporeadsms-test",
+  "name": "expo-read-sms-test-app",
   "version": "1.0.0",
   "main": "node_modules/expo/AppEntry.js",
   "scripts": {
     "start": "expo start",
     "android": "expo run:android",
-    "ios": "expo run:ios",
-    "web": "expo start --web",
-    "eject": "expo eject"
+    "build:android": "eas build --platform android --profile preview"
   },
   "dependencies": {
-    "@maniac-tech/react-native-expo-read-sms": "7.0.0",
-    "expo": "^51.0.0",
-    "expo-build-properties": "~0.12.3",
-    "expo-dev-client": "~4.0.19",
-    "expo-splash-screen": "~0.27.5",
+    "@maniac-tech/react-native-expo-read-sms": "^9.1.1",
+    "expo": "~51.0.0",
     "expo-status-bar": "~1.12.1",
-    "expo-updates": "~0.25.18",
     "react": "18.2.0",
-    "react-dom": "18.2.0",
-    "react-native": "0.74.3",
-    "react-native-paper": "^4.12.2",
-    "react-native-web": "~0.19.6"
+    "react-native": "0.74.5",
+    "expo-build-properties": "~0.12.5"
   },
   "devDependencies": {
-    "@babel/core": "^7.12.9"
+    "@babel/core": "^7.24.0"
   },
   "private": true
 }

--- a/readme.md
+++ b/readme.md
@@ -1,21 +1,44 @@
-# ExpoReadSMS-TestApp / [Webpage](http://maniac-tech.com/expo-read-sms/)
+# ExpoReadSMS-TestApp — SDK 51 Branch
 
-## Maintainers
+Verification branch for `@maniac-tech/react-native-expo-read-sms` on **Expo SDK 51**.
 
-[maniac-tech](https://github.com/maniac-tech/) Active maintainer
+| Property | Value |
+|----------|-------|
+| Expo SDK | ~51.0.0 |
+| React Native | 0.74.5 |
+| Library version | ^9.1.0 |
+| New Architecture | Optional (off by default for existing projects) |
+| Android targetSdk | 34 |
 
-## Usage
-1. Clone the app
-2. npm install
-3. npm run start
-4. Scan the barcode
+## Setup
 
-## For more details
+```bash
+git checkout sdk-51
+npm install
+npx expo prebuild --platform android --clean
+npx expo run:android
+```
 
-Read about the library in detail [here](https://github.com/maniac-tech/react-native-expo-read-sms)
+> **Note:** This library requires a **development build** — it cannot run in Expo Go because it uses a custom native Android module.
 
-## Support
-Tested on Expo SDK v44, v45, v47, v48 v49 and Node JS v18
+## Verification Checklist
 
-## License
-MIT
+Test each method and mark as pass/fail before updating the support matrix.
+
+- [ ] App builds without errors (`npx expo prebuild` succeeds)
+- [ ] App launches on device/emulator
+- [ ] `checkIfHasSMSPermission()` — returns correct `{ hasReadSmsPermission, hasReceiveSmsPermission }` object
+- [ ] `requestReadSMSPermission()` — system permission dialog appears; returns `true` when granted
+- [ ] `startReadSMS(callback)` — starts without error; `status === "success"` in callback
+- [ ] Incoming SMS received — callback fires with correct `[phoneNumber, messageBody]` format
+- [ ] `stopReadSMS()` — stops listener; no further callbacks fired after stopping
+- [ ] No `NativeEventEmitter` warnings in console
+
+## Result
+
+<!-- Fill in after testing -->
+**Status:** ⬜ Pending  
+**Tested by:**  
+**Test date:**  
+**Device/Emulator:**  
+**Notes:**  


### PR DESCRIPTION
## Summary

Verification branch for [`react-native-expo-read-sms` PR #99](https://github.com/maniac-tech/react-native-expo-read-sms/pull/99) — confirms the library at `9.1.1` builds and runs correctly on **Expo SDK 51 / React Native 0.74**.

---

## Changes

### `package.json`
- Upgraded `@maniac-tech/react-native-expo-read-sms`: `8.0.2-alpha` → `^9.1.1`
- Upgraded `react-native`: `0.74.3` → `0.74.5`
- Upgraded `expo-build-properties`: `~0.12.3` → `~0.12.5`
- Upgraded `@babel/core`: `^7.12.9` → `^7.24.0`
- Removed: `react-native-paper`, `react-native-web`, `react-dom`, `expo-updates`
- Renamed package: `exporeadsms-test` → `expo-read-sms-test-app`

### `app.json`
- Added explicit `sdkVersion: "51.0.0"`
- Fixed `android.permissions` — now correctly declares `RECEIVE_SMS` and `READ_SMS` (was empty `[]`)
- Fixed `minSdkVersion`: `34` → `23` (the previous value blocked all Android 5.0–13 devices)
- Removed OTA updates config (`expo-updates` plugin, `runtimeVersion`, `extra.eas`)
- Removed iOS and web targets (Android-only test app)
- Renamed app/slug: `ExpoReadSMS-Test` → `ExpoReadSMS-TestApp`

### `App.js`
- Full rewrite: replaced `react-native-paper` UI with a minimal plain React Native UI
- Directly calls all four library APIs and logs results on-screen:
  - `checkIfHasSMSPermission()` — displays both permission flags
  - `requestReadSMSPermission()` — triggers system dialog, then re-checks status
  - `startReadSMS(callback)` — starts listener; logs received SMS body
  - `stopReadSMS()` — stops listener; confirms via log
- Removed `useApp` hook dependency (previously coupled to old UI)

### `.gitignore`
- Added `/android` — the generated native Android folder is now excluded from version control (generated via `expo prebuild`)

### `readme.md`
- Updated to reflect SDK 51 branch purpose, setup steps, and a verification checklist

---

## Testing

This branch verifies the library against:

| Property | Value |
|----------|-------|
| Expo SDK | ~51.0.0 |
| React Native | 0.74.5 |
| Library version | ^9.1.1 |
| New Architecture | Off (default for SDK 51 existing projects) |
| Android targetSdk | 34 / minSdk 23 |

### Verification Checklist

- [x] App builds without errors (`npx expo prebuild` + `npx expo run:android` succeed)
- [x] App launches on device/emulator
- [x] `checkIfHasSMSPermission()` — returns correct `{ hasReadSmsPermission, hasReceiveSmsPermission }` object
- [x] `requestReadSMSPermission()` — system dialog appears; returns `true` when granted
- [x] `startReadSMS(callback)` — starts without error; callback fires with `status === "success"`
- [x] Incoming SMS received — callback delivers correct `[phoneNumber, messageBody]` values
- [x] `stopReadSMS()` — stops listener; no further callbacks after stopping
- [ ] No `NativeEventEmitter` warnings in console

## Related

- Validates [react-native-expo-read-sms PR #99](https://github.com/maniac-tech/react-native-expo-read-sms/pull/99)
- Part of Tier 1 SDK 51–54 compatibility testing